### PR TITLE
use PAT instead of GITHUB_TOKEN in tagpr to trigger release workflow

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -18,4 +18,4 @@ jobs:
       
       - uses: Songmu/tagpr@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
GITHUB_TOKENで打たれたタグはGitHub Actionsの制限により他のワークフローをトリガーしないため、PATに変更してrelease.ymlが発火するようにする。