### PR TITLE
use PAT for checkout in tagpr to ensure tag push triggers release workflow

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          token: ${{ secrets.GH_PAT }}
           persist-credentials: true
       
       - uses: Songmu/tagpr@v1


### PR DESCRIPTION
checkoutのtokenもPATに変更し、tagprがgit pushでタグを打つ際にPATの認証情報が使われるようにする。