### PR TITLE
Release for v0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [v0.0.4](https://github.com/rnakamine/kubectl-aws-sso-login/compare/v0.0.3...v0.0.4) - 2026-02-24
 - use PAT for checkout in tagpr to ensure tag push triggers release workflow by @rnakamine in https://github.com/rnakamine/kubectl-aws-sso-login/pull/7
 
+## [v0.0.4](https://github.com/rnakamine/kubectl-aws-sso-login/compare/v0.0.3...v0.0.4) - 2026-02-24
+- use PAT for checkout in tagpr to ensure tag push triggers release workflow by @rnakamine in https://github.com/rnakamine/kubectl-aws-sso-login/pull/7
+
 ## [v0.0.3](https://github.com/rnakamine/kubectl-aws-sso-login/compare/v0.0.2...v0.0.3) - 2026-02-24
 - use PAT instead of GITHUB_TOKEN in tagpr to trigger release workflow by @rnakamine in https://github.com/rnakamine/kubectl-aws-sso-login/pull/4
 


### PR DESCRIPTION
This pull request is for the next release as v0.0.4 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.4 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* use PAT for checkout in tagpr to ensure tag push triggers release workflow by @rnakamine in https://github.com/rnakamine/kubectl-aws-sso-login/pull/7


**Full Changelog**: https://github.com/rnakamine/kubectl-aws-sso-login/compare/v0.0.3...tagpr-from-v0.0.3