### PR TITLE
update versionFile to version.go and restrict ci to Go file changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: ci
 
 on:
   push:
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - "Makefile"
 
 jobs:
   test:

--- a/.tagpr
+++ b/.tagpr
@@ -48,5 +48,5 @@
 [tagpr]
 	vPrefix = true
 	releaseBranch = main
-	versionFile = -
+	versionFile = pkg/version/version.go
 	release = false


### PR DESCRIPTION
- `.tagpr`: `versionFile` を `pkg/version/version.go` に変更し、リリース時にバージョンが自動更新されるようにする
- `ci.yml`: `*.go` / `go.mod` / `go.sum` / `Makefile` 変更時のみ発火するようにパスフィルターを追加する