### PR TITLE
sync version.go to current tag v0.0.4

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var Version = "0.0.1"
+var Version = "0.0.4"


### PR DESCRIPTION
version.goが0.0.1のままだったためtagprが誤ったバージョンを検出していたので、現在の最新タグv0.0.4に合わせて修正する。