### PR TITLE
Release for v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.0.6](https://github.com/rnakamine/kubectl-aws-sso-login/compare/v0.0.5...v0.0.6) - 2026-02-24
+- fix duplicate entries in CHANGELOG.md by @rnakamine in https://github.com/rnakamine/kubectl-aws-sso-login/pull/15
+
 ## [v0.0.5](https://github.com/rnakamine/kubectl-aws-sso-login/compare/v0.0.4...v0.0.5) - 2026-02-24
 - update versionFile to version.go and restrict ci to Go file changes by @rnakamine in https://github.com/rnakamine/kubectl-aws-sso-login/pull/10
 - sync version.go to current tag v0.0.4 by @rnakamine in https://github.com/rnakamine/kubectl-aws-sso-login/pull/12

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var Version = "0.0.5"
+var Version = "0.0.6"


### PR DESCRIPTION
This pull request is for the next release as v0.0.6 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.6 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.5" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix duplicate entries in CHANGELOG.md by @rnakamine in https://github.com/rnakamine/kubectl-aws-sso-login/pull/15


**Full Changelog**: https://github.com/rnakamine/kubectl-aws-sso-login/compare/v0.0.5...tagpr-from-v0.0.5